### PR TITLE
Fix benchmark, speed up string padding

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1,20 +1,26 @@
 'use strict'
 
 var Benchmark = require('benchmark')
+Benchmark.options.minSamples = 200
 var suite = new Benchmark.Suite()
 var date = require('.')
 
-suite.add('Y-m-d H:i:s', function () {
-  date('Y-m-d H:i:s')
-})
+// We need fixed dates so timing won't flicker just because there's less
+// or more string padding to do.
+var now1 = new Date(1075817162)   // 2004-02-03 15:06:02
+var now2 = new Date(1416696170)   // 2014-11-22 23:42:50
 
-suite.add('c', function () {
-  date('c')
-})
+function addFmt (fmt) {
+  suite.add(fmt, function () {
+    date(fmt, now1)
+    date(fmt, now2)
+  })
+}
 
-suite.add('r', function () {
-  date('r')
-})
+addFmt('Y-m-d H:i:s')
+addFmt('c')
+addFmt('r')
+addFmt('S z')
 
 suite.on('cycle', function (event) {
   console.log(String(event.target))

--- a/marked-benchmark.sh
+++ b/marked-benchmark.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# -*- coding: utf-8, tab-width: 2 -*-
+for RUNS in {1..2}; do nodejs benchmark.js; done | sed -ure "s~ ops/~ $1&~"


### PR DESCRIPTION
In the first few benchmark runs I wondered why timings were so different. Turned out they used the current date in each iteration, so the amount of string padding changed based on when exactly the benchmark was started. =)

To compare both stages of this PR, I ran the benchmark twice each, marked the output with `:` for the original date code (with just benchmark fixed) and `#` for my speed boost patch, then sorted it:

```text
c x 10,089 : ops/sec ±0.76% (274 runs sampled)
c x 10,447 : ops/sec ±0.79% (274 runs sampled)
c x 10,714 # ops/sec ±0.74% (274 runs sampled)
c x 10,851 # ops/sec ±0.74% (274 runs sampled)
r x 8,647 : ops/sec ±1.02% (272 runs sampled)
r x 8,810 : ops/sec ±0.93% (274 runs sampled)
r x 9,056 # ops/sec ±0.96% (274 runs sampled)
r x 9,077 # ops/sec ±0.84% (274 runs sampled)
S z x 31,906 : ops/sec ±0.70% (274 runs sampled)
S z x 32,167 : ops/sec ±0.68% (274 runs sampled)
S z x 40,927 # ops/sec ±0.68% (274 runs sampled)
S z x 41,331 # ops/sec ±0.71% (273 runs sampled)
Y-m-d H:i:s x 14,471 : ops/sec ±0.76% (274 runs sampled)
Y-m-d H:i:s x 14,640 # ops/sec ±0.68% (274 runs sampled)
Y-m-d H:i:s x 14,700 # ops/sec ±0.81% (274 runs sampled)
Y-m-d H:i:s x 14,729 : ops/sec ±0.82% (274 runs sampled)
```